### PR TITLE
feat: Finish transfer functionality

### DIFF
--- a/src/services/transactions.service.test.ts
+++ b/src/services/transactions.service.test.ts
@@ -542,6 +542,14 @@ describe('transactions.service', () => {
       it.todo('when old tx type was transfer, delete opposite tx, update balance of opposite account, update current tx (set null all transfer-related attrs)');
     });
 
+    describe('transfer', () => {
+      it.todo('when amount is changed, amount should be updated for both transactions; balance of both accounts should be updated. Try different amounts');
+      it.todo('when accountFrom is changed, then update tx account to a new one, update balance for new account, update balance for old account');
+      it.todo('when accountTo is changed, then find opposite tx, update tx account to a new one, update balance for new account, update balance for old account');
+      it.todo('when old tx type was expense/income, and the new one is transfer, then run all the transfer creation flow');
+      it.todo('when old tx type was transfer, delete opposite tx, update balance of opposite account, update current tx (set null all transfer-related attrs)');
+    });
+
     it('handles error properly', async () => {
       jest
         .spyOn(Transactions, 'updateTransactionById')


### PR DESCRIPTION
This PR to finish https://github.com/letehaha/budget-tracker-be/pull/28

Part of https://github.com/letehaha/budget-tracker-fe/issues/19

TODOs:
- [x] When tx is created from A to B, it should be duplicated as B from A with the opposite amount.
- [ ] When tx is edited at A, it should also be edited at B, and vice versa.
- [x] When tx is deleted at A, it should also be deleted at B, and vice versa.
- [ ] When account A deleted, tx should keep `to` param's value as account B, but replace `from` param's value as account "Out of wallet". And vice versa.

Detailed TODOs:
- [ ] Get rid of AccountTypes table
- [x] editTransferTransaction
- - [x] [UPDATE AMOUNT OR DETAILS] Update data in both transactions, make `amount` opposite
- - [x] [UPDATE ACCOUNT] Do what is described above + update balances for old accounts
- [ ] update tx type to/from Transfer
- - [ ] if old tx type was Expense/Income and the new one is Transfer, then we need to run all the flow as on the Transfer creation (create oppositeTx)
- - [ ] if old tx type was Transfer, we need to delete oppositeTx and update that balance
- [x] deleteTransferTransaction
- - [x] delete tx itself
- - [x] delete opposite tx
- - [x] update balances everywhere
- [ ] deleteAccount. Cascadely delete data:
- - [ ] If `accountId === fromAccountId`, then delete tx and make `fromAccountId` for opposite tx as `null`
- - [ ] if `accountId === toAccountId`, then delete tx and make `toAccountId` for opposite tx as `null`

Instead of creating an internal account, we can just make the transfer's account `destination` field value `null`.